### PR TITLE
Add Bincode support

### DIFF
--- a/daedalus/Cargo.toml
+++ b/daedalus/Cargo.toml
@@ -22,3 +22,4 @@ bytes = "1"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 sha1 = { version = "0.6.0", features = ["std"]}
+bincode = {version = "2.0.0-rc", features = ["serde"], optional = true}

--- a/daedalus/Cargo.toml
+++ b/daedalus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daedalus"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Jai A <jaiagr+gpg@pm.me>"]
 edition = "2018"
 license = "MIT"

--- a/daedalus/src/minecraft.rs
+++ b/daedalus/src/minecraft.rs
@@ -4,9 +4,13 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+#[cfg(feature = "bincode")]
+use bincode::{Decode, Encode};
+
 /// The latest version of the format the model structs deserialize to
 pub const CURRENT_FORMAT_VERSION: usize = 0;
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 /// The version type
@@ -33,6 +37,7 @@ impl VersionType {
     }
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 /// A game version of Minecraft
@@ -45,8 +50,10 @@ pub struct Version {
     /// A link to additional information about the version
     pub url: String,
     /// The latest time a file in this version was updated
+    #[bincode(with_serde)]
     pub time: DateTime<Utc>,
     /// The time this version was released
+    #[bincode(with_serde)]
     pub release_time: DateTime<Utc>,
     /// The SHA1 hash of the additional information about the version
     pub sha1: String,
@@ -62,6 +69,7 @@ pub struct Version {
     pub assets_index_sha1: Option<String>,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 /// The latest snapshot and release of the game
 pub struct LatestVersion {
@@ -71,6 +79,7 @@ pub struct LatestVersion {
     pub snapshot: String,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 /// Data of all game versions of Minecraft
 pub struct VersionManifest {
@@ -85,12 +94,15 @@ pub const VERSION_MANIFEST_URL: &str =
     "https://launchermeta.mojang.com/mc/game/version_manifest_v2.json";
 
 /// Fetches a version manifest from the specified URL. If no URL is specified, the default is used.
-pub async fn fetch_version_manifest(url: Option<&str>) -> Result<VersionManifest, Error> {
+pub async fn fetch_version_manifest(
+    url: Option<&str>,
+) -> Result<VersionManifest, Error> {
     Ok(serde_json::from_slice(
         &download_file(url.unwrap_or(VERSION_MANIFEST_URL), None).await?,
     )?)
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 /// Information about the assets of the game
@@ -107,6 +119,7 @@ pub struct AssetIndex {
     pub url: String,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
 #[serde(rename_all = "snake_case")]
 /// The type of download
@@ -123,6 +136,7 @@ pub enum DownloadType {
     WindowsServer,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug)]
 /// Download information of a file
 pub struct Download {
@@ -134,6 +148,7 @@ pub struct Download {
     pub url: String,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug)]
 /// Download information of a library
 pub struct LibraryDownload {
@@ -147,6 +162,7 @@ pub struct LibraryDownload {
     pub url: String,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug)]
 /// A list of files that should be downloaded for libraries
 pub struct LibraryDownloads {
@@ -159,6 +175,7 @@ pub struct LibraryDownloads {
     pub classifiers: Option<HashMap<String, LibraryDownload>>,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 /// The action a rule can follow
@@ -169,6 +186,7 @@ pub enum RuleAction {
     Disallow,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash, Clone)]
 #[serde(rename_all = "snake_case")]
 /// An enum representing the different types of operating systems
@@ -183,6 +201,7 @@ pub enum Os {
     Unknown,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 /// A rule which depends on what OS the user is on
 pub struct OsRule {
@@ -197,6 +216,7 @@ pub struct OsRule {
     pub arch: Option<String>,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 /// A rule which depends on the toggled features of the launcher
 pub struct FeatureRule {
@@ -208,6 +228,7 @@ pub struct FeatureRule {
     pub has_demo_resolution: Option<bool>,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 /// A rule deciding whether a file is downloaded, an argument is used, etc.
 pub struct Rule {
@@ -221,6 +242,7 @@ pub struct Rule {
     pub features: Option<FeatureRule>,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug)]
 /// Information delegating the extraction of the library
 pub struct LibraryExtract {
@@ -229,6 +251,7 @@ pub struct LibraryExtract {
     pub exclude: Option<Vec<String>>,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 /// Information about the java version the game needs
@@ -239,6 +262,7 @@ pub struct JavaVersion {
     pub major_version: u32,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug)]
 /// A library which the game relies on to run
 pub struct Library {
@@ -271,6 +295,7 @@ fn default_include_in_classpath() -> bool {
     true
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 /// A container for an argument or multiple arguments
@@ -281,6 +306,7 @@ pub enum ArgumentValue {
     Many(Vec<String>),
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 /// A command line argument passed to a program
@@ -296,6 +322,7 @@ pub enum Argument {
     },
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 /// The type of argument
@@ -306,6 +333,7 @@ pub enum ArgumentType {
     Jvm,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 /// Information about a version
@@ -334,8 +362,10 @@ pub struct VersionInfo {
     /// The minimum version of the Minecraft Launcher that can run this version of the game
     pub minimum_launcher_version: u32,
     /// The time that the version was released
+    #[bincode(with_serde)]
     pub release_time: DateTime<Utc>,
     /// The latest time a file in this version was updated
+    #[bincode(with_serde)]
     pub time: DateTime<Utc>,
     #[serde(rename = "type")]
     /// The type of version
@@ -349,12 +379,15 @@ pub struct VersionInfo {
 }
 
 /// Fetches detailed information about a version from the manifest
-pub async fn fetch_version_info(version: &Version) -> Result<VersionInfo, Error> {
+pub async fn fetch_version_info(
+    version: &Version,
+) -> Result<VersionInfo, Error> {
     Ok(serde_json::from_slice(
         &download_file(&version.url, Some(&version.sha1)).await?,
     )?)
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug)]
 /// An asset of the game
 pub struct Asset {
@@ -364,6 +397,7 @@ pub struct Asset {
     pub size: u32,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug)]
 /// An index containing all assets the game needs
 pub struct AssetsIndex {
@@ -372,8 +406,14 @@ pub struct AssetsIndex {
 }
 
 /// Fetches the assets index from the version info
-pub async fn fetch_assets_index(version: &VersionInfo) -> Result<AssetsIndex, Error> {
+pub async fn fetch_assets_index(
+    version: &VersionInfo,
+) -> Result<AssetsIndex, Error> {
     Ok(serde_json::from_slice(
-        &download_file(&version.asset_index.url, Some(&version.asset_index.sha1)).await?,
+        &download_file(
+            &version.asset_index.url,
+            Some(&version.asset_index.sha1),
+        )
+        .await?,
     )?)
 }

--- a/daedalus/src/minecraft.rs
+++ b/daedalus/src/minecraft.rs
@@ -50,10 +50,10 @@ pub struct Version {
     /// A link to additional information about the version
     pub url: String,
     /// The latest time a file in this version was updated
-    #[bincode(with_serde)]
+    #[cfg_attr(feature = "bincode", bincode(with_serde))]
     pub time: DateTime<Utc>,
     /// The time this version was released
-    #[bincode(with_serde)]
+    #[cfg_attr(feature = "bincode", bincode(with_serde))]
     pub release_time: DateTime<Utc>,
     /// The SHA1 hash of the additional information about the version
     pub sha1: String,
@@ -362,10 +362,10 @@ pub struct VersionInfo {
     /// The minimum version of the Minecraft Launcher that can run this version of the game
     pub minimum_launcher_version: u32,
     /// The time that the version was released
-    #[bincode(with_serde)]
+    #[cfg_attr(feature = "bincode", bincode(with_serde))]
     pub release_time: DateTime<Utc>,
     /// The latest time a file in this version was updated
-    #[bincode(with_serde)]
+    #[cfg_attr(feature = "bincode", bincode(with_serde))]
     pub time: DateTime<Utc>,
     #[serde(rename = "type")]
     /// The type of version

--- a/daedalus/src/modded.rs
+++ b/daedalus/src/modded.rs
@@ -1,9 +1,14 @@
 use crate::{download_file, Error};
 
-use crate::minecraft::{Argument, ArgumentType, Library, VersionInfo, VersionType};
+use crate::minecraft::{
+    Argument, ArgumentType, Library, VersionInfo, VersionType,
+};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+#[cfg(feature = "bincode")]
+use bincode::{Decode, Encode};
 
 /// The latest version of the format the fabric model structs deserialize to
 pub const CURRENT_FABRIC_FORMAT_VERSION: usize = 0;
@@ -11,6 +16,7 @@ pub const CURRENT_FABRIC_FORMAT_VERSION: usize = 0;
 pub const CURRENT_FORGE_FORMAT_VERSION: usize = 0;
 
 /// A data variable entry that depends on the side of the installation
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SidedDataEntry {
     /// The value on the client
@@ -19,6 +25,7 @@ pub struct SidedDataEntry {
     pub server: String,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 /// A partial version returned by fabric meta
@@ -28,8 +35,10 @@ pub struct PartialVersionInfo {
     /// The version ID this partial version inherits from
     pub inherits_from: String,
     /// The time that the version was released
+    #[bincode(with_serde)]
     pub release_time: DateTime<Utc>,
     /// The latest time a file in this version was updated
+    #[bincode(with_serde)]
     pub time: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The classpath to the main class to launch the game
@@ -54,6 +63,7 @@ pub struct PartialVersionInfo {
 }
 
 /// A processor to be ran after downloading the files
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Processor {
     /// Maven coordinates for the JAR library of this processor.
@@ -72,12 +82,17 @@ pub struct Processor {
 }
 
 /// Fetches the version manifest of a game version's URL
-pub async fn fetch_partial_version(url: &str) -> Result<PartialVersionInfo, Error> {
+pub async fn fetch_partial_version(
+    url: &str,
+) -> Result<PartialVersionInfo, Error> {
     Ok(serde_json::from_slice(&download_file(url, None).await?)?)
 }
 
 /// Merges a partial version into a complete one
-pub fn merge_partial_version(partial: PartialVersionInfo, merge: VersionInfo) -> VersionInfo {
+pub fn merge_partial_version(
+    partial: PartialVersionInfo,
+    merge: VersionInfo,
+) -> VersionInfo {
     VersionInfo {
         arguments: if let Some(partial_args) = partial.arguments {
             if let Some(merge_args) = merge.arguments {
@@ -133,6 +148,7 @@ pub fn merge_partial_version(partial: PartialVersionInfo, merge: VersionInfo) ->
     }
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 /// A manifest containing information about a mod loader's versions
@@ -141,6 +157,7 @@ pub struct Manifest {
     pub game_versions: Vec<Version>,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 ///  A game version of Minecraft
 pub struct Version {
@@ -150,6 +167,7 @@ pub struct Version {
     pub loaders: Vec<LoaderVersion>,
 }
 
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 /// A version of a Minecraft mod loader
 pub struct LoaderVersion {

--- a/daedalus/src/modded.rs
+++ b/daedalus/src/modded.rs
@@ -35,10 +35,10 @@ pub struct PartialVersionInfo {
     /// The version ID this partial version inherits from
     pub inherits_from: String,
     /// The time that the version was released
-    #[bincode(with_serde)]
+    #[cfg_attr(feature = "bincode", bincode(with_serde))]
     pub release_time: DateTime<Utc>,
     /// The latest time a file in this version was updated
-    #[bincode(with_serde)]
+    #[cfg_attr(feature = "bincode", bincode(with_serde))]
     pub time: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The classpath to the main class to launch the game

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2018"
+max_width = 80


### PR DESCRIPTION
This adds support for Bincode binary encoding, allowing for more compact storage of objects. It is locked behind the `bincode` feature, and primarily is needed to correctly encode metadata in the Theseus refactor's database. This is needed in order to properly encode fields, as Bincode does not encode the metadata to skip a completely absent field.