### PR TITLE
fix: Neoforge version generating

### DIFF
--- a/daedalus_client/src/neo.rs
+++ b/daedalus_client/src/neo.rs
@@ -466,7 +466,11 @@ pub async fn fetch_maven_metadata(
 
         if let Some(major) = parts.next() {
             if let Some(minor) = parts.next() {
-                let game_version = format!("1.{}.{}", major, minor);
+                let game_version = if minor == "0" {
+                    format!("1.{}", major)
+                } else {
+                    format!("1.{}.{}", major, minor)
+                };
 
                 map.entry(game_version.clone()).or_default().push((
                     original.clone(),


### PR DESCRIPTION
Fixes version formatting to produce '1.21' instead of '1.21.0' for 'full' versions, addressing issues with version selection in Theseus.  This adjustment ensures consistency with other loaders.

**Note: Now it is impossible to play 1.21 in Modrinth app!**